### PR TITLE
fix: InstallIngress upgrading ingress nginx to 3.15.2

### DIFF
--- a/cmd/kind/kind.go
+++ b/cmd/kind/kind.go
@@ -52,7 +52,7 @@ func (Kind) Create(ctx context.Context) {
 func (Kind) InstallIngress() error {
 	log.Printf("Install Ingress to Cluster")
 
-	nginxVersion := "2.11.1"
+	nginxVersion := "3.15.2"
 
 	urlReleaseBase := fmt.Sprintf(
 		"https://raw.githubusercontent.com/kubernetes/ingress-nginx/ingress-nginx-%s",


### PR DESCRIPTION
Upgrade ingress nginx version to fix error when installing from `2.11.1`:

```
error: unable to recognize "https://raw.githubusercontent.com/kubernetes/ingress-nginx/ingress-nginx-2.11.1/deploy/static/provider/kind/deploy.yaml": no matches for kind "ValidatingWebhookConfiguration" in version "admissionregistration.k8s.io/v1beta1"
Error: running "kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/ingress-nginx-2.11.1/deploy/static/provider/kind/deploy.yaml --wait=true" failed with exit code 1
exit status 1
```

**Notes:**
- Issue detected when attempting to contribute to [denouche/terraform-provider-awx](https://github.com/denouche/terraform-provider-awx#local-development) which depends on this project.